### PR TITLE
feat: osmosis

### DIFF
--- a/contracts/strategy-osmosis/src/execute/stake.rs
+++ b/contracts/strategy-osmosis/src/execute/stake.rs
@@ -1,8 +1,8 @@
 use crate::error::ContractError;
-use crate::msgs::StakeMsg;
 use crate::state::{DepositInfo, CONFIG, DEPOSITS, STAKE_RATE_MULTIPLIER, STATE};
 use cosmwasm_std::{Coin, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw_utils::one_coin;
+use strategy::v1::msgs::StakeMsg;
 use ununifi_binding::v1::binding::UnunifiMsg;
 
 pub fn execute_stake(

--- a/contracts/strategy-osmosis/src/execute/unstake.rs
+++ b/contracts/strategy-osmosis/src/execute/unstake.rs
@@ -1,12 +1,11 @@
 use crate::error::{ContractError, NoDeposit};
-use crate::msgs::UnstakeMsg;
 use crate::query::unbondings::{query_unbondings, UNBONDING_ITEM_LIMIT};
 use crate::state::{
     DepositInfo, Unbonding, DEPOSITS, HOST_LP_RATE_MULTIPLIER, STAKE_RATE_MULTIPLIER, STATE,
     UNBONDINGS,
 };
-
 use cosmwasm_std::{DepsMut, Env, MessageInfo, Response, StdResult, Uint128};
+use strategy::v1::msgs::UnstakeMsg;
 use ununifi_binding::v1::binding::UnunifiMsg;
 
 pub fn execute_unstake(

--- a/contracts/strategy-osmosis/src/msgs.rs
+++ b/contracts/strategy-osmosis/src/msgs.rs
@@ -2,6 +2,7 @@ use crate::state::DepositToken;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::IbcEndpoint;
 use cosmwasm_std::{Coin, Decimal, Uint128};
+use strategy::v1::msgs::{EpochMsg, StakeMsg, UnstakeMsg};
 
 #[cw_serde]
 pub struct InstantiateMsg {
@@ -51,18 +52,6 @@ pub struct IcqBalanceCallbackMsg {
 
 #[cw_serde]
 pub struct IbcTransferCallbackMsg {}
-
-#[cw_serde]
-pub struct StakeMsg {}
-
-#[cw_serde]
-pub struct UnstakeMsg {
-    pub share_amount: Uint128,
-    pub recipient: Option<String>,
-}
-
-#[cw_serde]
-pub struct EpochMsg {}
 
 #[cw_serde]
 pub struct IbcTransferToHostMsg {}

--- a/contracts/strategy-osmosis/tests/test_stake.rs
+++ b/contracts/strategy-osmosis/tests/test_stake.rs
@@ -1,9 +1,10 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{coins, Uint128};
 use helpers::th_query;
+use strategy::v1::msgs::StakeMsg;
 use strategy_osmosis::error::ContractError;
 use strategy_osmosis::execute::stake::execute_stake;
-use strategy_osmosis::msgs::{QueryMsg, StakeMsg};
+use strategy_osmosis::msgs::QueryMsg;
 use strategy_osmosis::state::State;
 
 use crate::helpers::setup;

--- a/contracts/strategy-osmosis/tests/test_unstake.rs
+++ b/contracts/strategy-osmosis/tests/test_unstake.rs
@@ -1,9 +1,9 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{coins, Uint128};
+use strategy::v1::msgs::{StakeMsg, UnstakeMsg};
 use strategy_osmosis::error::{ContractError, NoDeposit};
 use strategy_osmosis::execute::stake::execute_stake;
 use strategy_osmosis::execute::unstake::execute_unstake;
-use strategy_osmosis::msgs::{StakeMsg, UnstakeMsg};
 
 use crate::helpers::setup;
 

--- a/packages/strategy/src/v1/msgs.rs
+++ b/packages/strategy/src/v1/msgs.rs
@@ -17,7 +17,7 @@ pub struct StakeMsg {}
 
 #[cw_serde]
 pub struct UnstakeMsg {
-    pub amount: Uint128,
+    pub share_amount: Uint128,
     pub recipient: Option<String>,
 }
 
@@ -35,6 +35,8 @@ pub enum QueryMsg {
     Amounts { addr: String },
     #[returns(FeeResp)]
     Fee {},
+    #[returns(KycResp)]
+    Kyc {},
 }
 
 #[cw_serde]
@@ -61,6 +63,12 @@ pub struct FeeResp {
     pub withdraw_fee_rate: Decimal,
     pub min_withdraw_fee: Option<Uint128>,
     pub max_withdraw_fee: Option<Uint128>,
+}
+
+#[cw_serde]
+pub struct KycResp {
+    pub kyc_required: bool,
+    pub trusted_provider_ids: Vec<u64>,
 }
 
 #[cw_serde]


### PR DESCRIPTION
- added `Kyc` Query for custodian strategy
- removed `StakeMsg` definition from osmosis (changed to use v1 package)